### PR TITLE
update to use base docker image (1.8.3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/cloudantprovider:1.8.2
+FROM openwhisk/cloudantprovider:1.8.3
 
 COPY package.json /cloudantTrigger/
 RUN cd /cloudantTrigger && npm install --production


### PR DESCRIPTION
use base image 1.8.3 from https://github.com/apache/incubator-openwhisk-package-cloudant/pull/188