### PR TITLE
Bump node version to 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24.0
+FROM node:12.21.0
 
 RUN apt-get update && apt-get upgrade -y
 

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -22,7 +22,7 @@ DB_URL="$3"
 DB_NAME="${4}cloudanttrigger"
 APIHOST="$5"
 WORKERS="$6"
-ACTION_RUNTIME_VERSION=${ACTION_RUNTIME_VERSION:="nodejs:10"}
+ACTION_RUNTIME_VERSION=${ACTION_RUNTIME_VERSION:="nodejs:12"}
 
 # If the auth key file exists, read the key in the file. Otherwise, take the
 # first argument as the key itself.


### PR DESCRIPTION
This PR bumps the base Docker image and the default runtime version to Node.js 12.