### PR TITLE
Follow image updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.1
+FROM node:12
 
 RUN apt-get update && apt-get upgrade -y
 


### PR DESCRIPTION
An PSIRT issue required update to 12.22.2 - we get this and future fixes automatically by following the image updates