### PR TITLE
Add Pause and Resume capability to cloudant provider 

### DIFF
--- a/provider/app.js
+++ b/provider/app.js
@@ -29,7 +29,7 @@ var logger = require('./Logger');
 
 var ProviderManager = require('./lib/manager.js');
 var ProviderHealth = require('./lib/health.js');
-var ProviderHealth = require('./lib/health.js');
+var ProviderActivation = require('./lib/active.js');
 var ProviderPauseResume = require('./lib/pauseResume.js');
 var constants = require('./lib/constants.js');
 

--- a/provider/app.js
+++ b/provider/app.js
@@ -29,7 +29,8 @@ var logger = require('./Logger');
 
 var ProviderManager = require('./lib/manager.js');
 var ProviderHealth = require('./lib/health.js');
-var ProviderActivation = require('./lib/active.js');
+var ProviderHealth = require('./lib/health.js');
+var ProviderPauseResume = require('./lib/pauseResume.js');
 var constants = require('./lib/constants.js');
 
 // Initialize the Express Application
@@ -141,12 +142,17 @@ function init(server) {
     .then(() => {
         var providerHealth = new ProviderHealth(logger, providerManager);
         var providerActivation = new ProviderActivation(logger, providerManager);
+        var providerPauseResume = new ProviderPauseResume(logger, providerManager);
 
         // Health Endpoint
         app.get(providerHealth.endPoint, providerManager.authorize, providerHealth.health);
 
         // Activation Endpoint
         app.get(providerActivation.endPoint, providerManager.authorize, providerActivation.active);
+        
+        // PauseResume Endpoint
+        app.get(providerPauseResume.endPoint, providerManager.authorize, providerPauseResume.pauseresume);
+
 
         providerManager.initAllTriggers();
 

--- a/provider/lib/health.js
+++ b/provider/lib/health.js
@@ -40,8 +40,8 @@ module.exports = function (logger, manager) {
 
         // Write log info if the health enpoint is called when no monitoring status 
         // is available. (Maybe the self-test has not already executed after a restart) 
-        if ( !(monitorStatus) || monitoringStatus == '' ) {
-            logger.info(method, triggerNamePrefix, 'No MonitorStatus available at the moment.(Potentially restarted cloudant backendprovider in the last hour)');
+        if ( !monitorStatus ) {
+            logger.info(method, triggerNamePrefix, 'No MonitorStatus available.(Potentially restarted cloudant backendprovider in the last hour)');
         }
 
         // get all system stats in parallel

--- a/provider/lib/health.js
+++ b/provider/lib/health.js
@@ -27,14 +27,22 @@ module.exports = function (logger, manager) {
     this.endPoint = '/health';
 
     var triggerName;
+    var triggerNamePrefix = 'cloudant_' + manager.worker + manager.host + '_';
     var canaryDocID;
     var monitorStatus;
     var monitorStages = ['triggerStarted', 'triggerFired', 'triggerStopped'];
 
     // Health Logic
     this.health = function (req, res) {
-
+        var method = 'health';
+        
         var stats = {triggerCount: Object.keys(manager.triggers).length};
+
+        // Write log info if the health enpoint is called when no monitoring status 
+        // is available. (Maybe the self-test has not already executed after a restart) 
+        if ( !(monitorStatus) || monitoringStatus == '' ) {
+            logger.info(method, triggerNamePrefix, 'No MonitorStatus available at the moment.(Potentially restarted cloudant backendprovider in the last hour)');
+        }
 
         // get all system stats in parallel
         Promise.all([

--- a/provider/lib/health.js
+++ b/provider/lib/health.js
@@ -41,7 +41,7 @@ module.exports = function (logger, manager) {
         // Write log info if the health enpoint is called when no monitoring status 
         // is available. (Maybe the self-test has not already executed after a restart) 
         if ( !monitorStatus ) {
-            logger.info(method, triggerNamePrefix, 'No MonitorStatus available.(Potentially restarted cloudant backendprovider in the last hour)');
+            logger.info(method, triggerNamePrefix, 'No MonitorStatus available.(Potentionally the cloudant backendprovider was restarted in the last hour)');
         }
 
         // get all system stats in parallel

--- a/provider/lib/health.js
+++ b/provider/lib/health.js
@@ -41,7 +41,7 @@ module.exports = function (logger, manager) {
         // Write log info if the health enpoint is called when no monitoring status 
         // is available. (Maybe the self-test has not already executed after a restart) 
         if ( !monitorStatus ) {
-            logger.info(method, triggerNamePrefix, 'No MonitorStatus available.(Potentionally the cloudant backendprovider was restarted in the last hour)');
+            logger.info(method, triggerNamePrefix, 'No MonitorStatus available.(Potentially the cloudant backendprovider was restarted in the last hour)');
         }
 
         // get all system stats in parallel

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -39,6 +39,7 @@ module.exports = function (logger, triggerDB, redisClient) {
     this.redisField = constants.REDIS_FIELD;
     this.uriHost = 'https://' + this.routerHost;
     this.monitorStatus = {};
+    this.pauseResumeEnabled = "true";   //* By default it is switched ON
 
     // Add a trigger: listen for changes and dispatch.
     this.createTrigger = function (triggerData, isStartup) {

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -39,7 +39,7 @@ module.exports = function (logger, triggerDB, redisClient) {
     this.redisField = constants.REDIS_FIELD;
     this.uriHost = 'https://' + this.routerHost;
     this.monitorStatus = {};
-    this.pauseResumeEnabled = "true";   //* By default it is switched ON
+    this.pauseResumeEnabled = "false";   //* By default it is switched OFF
 
     // Add a trigger: listen for changes and dispatch.
     this.createTrigger = function (triggerData, isStartup) {
@@ -283,7 +283,7 @@ module.exports = function (logger, triggerDB, redisClient) {
                                 //***************************************************************************************
                                 var timeout = 1000;  //default 
                                 if ( statusCode === 429 && self.pauseResumeEnabled == "true" ) {
-                                    timeout = 5000;
+                                    timeout = 6000;
                                     try {
                                       triggerData.feed.pause();  
                                       logger.info(method, 'Paused receiving events for trigger:', triggerIdentifier, ' issued while Retry Count:', (retryCount + 1));    
@@ -307,7 +307,12 @@ module.exports = function (logger, triggerDB, redisClient) {
                                 }else if ( statusCode === 429 && self.pauseResumeEnabled != "true" && retryCount === 0 ) { 
                                     timeout = 60000;
                                 }else{
-                                    timeout =  1000 * Math.pow(retryCount + 1, 2);
+                                    //*********************************************************************
+                                    //* exponential handling of timeouts for retries has no effect on reaching 
+                                    //* limits. -> so use a  fix value for timeout 
+                                    //**********************************************************************
+                                    //timeout =  1000 * Math.pow(retryCount + 1, 2);
+                                    timeout = 6000;
                                 }
                                 logger.info(method, 'Attempting to fire trigger again', triggerIdentifier, 'Retry Count:', (retryCount + 1));
                                 

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -296,23 +296,24 @@ module.exports = function (logger, triggerDB, redisClient) {
                                           triggerData.feed.resume(); 
                                           logger.info(method, 'Resumed receiving events for trigger:', triggerIdentifier, 'issued while Retry Count:', (retryCount + 1));
                                         } catch (err) {
-                                          logger.info(method, 'Failed on Resume the feed. Error: ', err );  
+                                          logger.error(method, 'Failed on Resume the feed. Error: ', err );  
                                           //** continue processing without pausing/resuming this trigger
                                         }       
                                       }, 120000);
                                     } catch (err) {
-                                      logger.info(method, 'Failed on Pause the feed. Error: ', err );  
+                                      logger.error(method, 'Failed on Pause the feed. Error: ', err );  
                                       //** continue processing without pausing/resuming this trigger
                                     }  
                                 }else if ( statusCode === 429 && self.pauseResumeEnabled != "true" && retryCount === 0 ) { 
                                     timeout = 60000;
-                                }else{
+                                }else if ( statusCode === 429 && self.pauseResumeEnabled != "true" ) { 
                                     //*********************************************************************
                                     //* exponential handling of timeouts for retries has no effect on reaching 
                                     //* limits. -> so use a  fix value for timeout 
-                                    //**********************************************************************
-                                    //timeout =  1000 * Math.pow(retryCount + 1, 2);
+                                    //********************************************************************** 
                                     timeout = 6000;
+                                }else{
+                                    timeout =  1000 * Math.pow(retryCount + 1, 2);
                                 }
                                 logger.info(method, 'Attempting to fire trigger again', triggerIdentifier, 'Retry Count:', (retryCount + 1));
                                 

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * See the License for the specific language governing permissions and 
  * limitations under the License.
  */
 

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -285,7 +285,7 @@ module.exports = function (logger, triggerDB, redisClient) {
                                 if ( statusCode === 429 && self.pauseResumeEnabled == "true" ) {
                                     timeout = 5000;
                                     try {
-                                      triggerdata.feed.pause();  
+                                      triggerData.feed.pause();  
                                       logger.info(method, 'Paused receiving events for trigger:', triggerIdentifier, ' issued while Retry Count:', (retryCount + 1));    
                                       //********************************************************************
                                       //* schedule the asynchronous function in 120 sec resuming the feed  
@@ -293,7 +293,7 @@ module.exports = function (logger, triggerDB, redisClient) {
                                       //******************************************************************** 
                                       setTimeout(function () {
                                         try {                                           
-                                          triggerdata.feed.resume(); 
+                                          triggerData.feed.resume(); 
                                           logger.info(method, 'Resumed receiving events for trigger:', triggerIdentifier, 'issued while Retry Count:', (retryCount + 1));
                                         } catch (err) {
                                           logger.info(method, 'Failed on Resume the feed. Error: ', err );  

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -304,7 +304,7 @@ module.exports = function (logger, triggerDB, redisClient) {
                                       logger.info(method, 'Failed on Pause the feed. Error: ', err );  
                                       //** continue processing without pausing/resuming this trigger
                                     }  
-                                }else ( statusCode === 429 && self.pauseResumeEnabled != "true" && retryCount === 0 ) {
+                                }else if ( statusCode === 429 && self.pauseResumeEnabled != "true" && retryCount === 0 ) { 
                                     timeout = 60000;
                                 }else{
                                     timeout =  1000 * Math.pow(retryCount + 1, 2);

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -304,7 +304,7 @@ module.exports = function (logger, triggerDB, redisClient) {
                                       logger.info(method, 'Failed on Pause the feed. Error: ', err );  
                                       //** continue processing without pausing/resuming this trigger
                                     }  
-                                }else statusCode === 429 && self.pauseResumeEnabled != "true" && retryCount === 0 ) {
+                                }else ( statusCode === 429 && self.pauseResumeEnabled != "true" && retryCount === 0 ) {
                                     timeout = 60000;
                                 }else{
                                     timeout =  1000 * Math.pow(retryCount + 1, 2);

--- a/provider/lib/pauseResume.js
+++ b/provider/lib/pauseResume.js
@@ -1,5 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Apache Software Foundation (ASF) under one or more 
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0

--- a/provider/lib/pauseResume.js
+++ b/provider/lib/pauseResume.js
@@ -48,12 +48,12 @@ module.exports = function (logger, manager) {
                 enabled: "false"
             });
         }else if ( req.query.enabled.length == 0 ){
-            logger.info( method, 'Pause/Resume capability status queried by operator');
+            logger.error( method, 'Pause/Resume capability status queried by operator');
             res.send({
                 enabled: manager.pauseResumeEnabled
             });
         }else {
-            logger.info( method, 'Request to change Pause/Resume capability contained incorrect arguments');
+            logger.error( method, 'Request to change Pause/Resume capability contained incorrect arguments');
             res.status(400).send({
                 message: 'Missing  parameter [/pauseresume?enabled=] in URL'
             });

--- a/provider/lib/pauseResume.js
+++ b/provider/lib/pauseResume.js
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function (logger, manager) {
+
+    //******************************************* 
+    //* pauseresume Endpoint 
+    //*  to set or query the pauseresume capability flag 
+    //* 
+    //* supports URL-encoded paramter only 
+    //* e.g  ../pauseresume?enabled=true   (set)
+    //*      ../pauseresume?enabled        (query)
+    //*******************************************
+    this.endPoint = '/pauseresume';
+
+    this.pauseresume = function (req, res) {
+        var method = 'pauseresume';
+        
+        //************************************
+        //* detect request details : 
+        //* enabled == true  --> switch ON 
+        //* enabled == false --> switch OFF 
+        //************************************
+        if ( "true" == req.query.enabled ) {  
+            logger.info( method, 'Pause/Resume capability enabled by operator');
+            manager.pauseResumeEnabled = "true";
+            res.send({
+                enabled: "true"
+            });
+        }else if ( "false" == req.query.enabled ) {
+            logger.info( method, 'Pause/Resume capability disabled by operator');
+            manager.pauseResumeEnabled = "false";
+            res.send({
+                enabled: "false"
+            });
+        }else if ( req.query.enabled.length == 0 ){
+            logger.info( method, 'Pause/Resume capability status queried by operator');
+            res.send({
+                enabled: manager.pauseResumeEnabled
+            });
+        }else {
+            logger.info( method, 'Request to change Pause/Resume capability contained incorrect arguments');
+            res.status(400).send({
+                message: 'Missing  parameter [/pauseresume?enabled=] in URL'
+            });
+        }
+    };
+};


### PR DESCRIPTION
In case of overload situations the  provider can  pause and resume  the reading of change events from the cloudant customer DB 