### PR TITLE
Follow lib heartbeat workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,12 @@ ADD package.json /cloudantTrigger/
 RUN echo "engine-strict=true" > /cloudantTrigger/.npmrc
 RUN cd /cloudantTrigger && npm install --omit=dev
 
+# 07/07/2023 :  FG - The used cloudant-follow lib npm package is out of support since 2022. Since the heartbeat 
+#               behaviour has changed in  IBM Cloud Cloudant DB HA-handling the heartbeats will occur with 
+#               longer delays. ( e.g follow lib has heartbeat setting of 30 sec, but DB respond sometimes only in 90 sec)
+#               So the HEARTBEAT_TIMEOUT_COEFFICIENT of the follow lib needs to be adpted. Because follow-lib package will 
+#               not be updated, this settings update needs to be done  during the provider image build by patching the feed.js file 
+
+RUN sed -i 's/HEARTBEAT_TIMEOUT_COEFFICIENT = 1.25;/HEARTBEAT_TIMEOUT_COEFFICIENT = 3.25;/g' /cloudantTrigger/node_modules/cloudant-follow/lib/feed.js
+
 ADD provider/. /cloudantTrigger/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ RUN cd /cloudantTrigger && npm install --omit=dev
 
 RUN sed -i 's/HEARTBEAT_TIMEOUT_COEFFICIENT = 1.25;/HEARTBEAT_TIMEOUT_COEFFICIENT = 3.25;/g' /cloudantTrigger/node_modules/cloudant-follow/lib/feed.js
 
+
 ADD provider/. /cloudantTrigger/


### PR DESCRIPTION
added the patching of the feed.js file  which is no more in a maintained package,  but  Cloudant DB team  provided a hint how to fix it with an  sed  command 