### PR TITLE
fixes the handling of network and DNS errors. Do no more disable trig…

### DIFF
--- a/provider/app.js
+++ b/provider/app.js
@@ -26,6 +26,8 @@ var express = require('express');
 var bodyParser = require('body-parser');
 var bluebird = require('bluebird');
 var logger = require('./Logger');
+const process = require('node:process');
+
 
 var ProviderManager = require('./lib/manager.js');
 var ProviderHealth = require('./lib/health.js');
@@ -150,6 +152,15 @@ function init(server) {
     var method = 'init';
     var cloudantDb;
     var providerManager;
+
+    //********************************************************************************
+    //* Since Nodejs16  UnhandledRejections result in process termination. To avoid 
+    //* this new behavior the process scope handler is registered
+    //******************************************************************************* 
+    process.on('unhandledRejection', (reason, promise) => {
+        logger.info(method, 'Cloudant provider caught an Unhandled Rejection at promise:' + promise + ' reason: ' +  reason );
+        //Application specific logging, throwing an error, or other logic here
+    });
 
     if (server !== null) {
         var address = server.address();

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -819,12 +819,18 @@ module.exports = function (logger, triggerDB, redisClient, databaseName) {
                                     } else {
                                         self.createTrigger(initTrigger(doc), true)
                                         .then(triggerIdentifier => {
-                                            logger.info(method, triggerIdentifier, 'created successfully');
+                                            logger.info(method, 'trigger ', triggerIdentifier, 'created successfully');
                                         })
                                         .catch(err => {
-                                            var message = 'Automatically disabled after receiving exception on init trigger: ' + err;
-                                            disableTrigger(triggerIdentifier, undefined, message);
-                                            logger.error(method, 'Disabled trigger', triggerIdentifier, 'due to exception:', err);
+                                            // GIT issue #86: Do no more automatically disable trigger on startup , because in case of a 
+                                            //                temporarily network/DNS error all triggers got disabled 
+                                            // var message = 'Automatically disabled after receiving exception on init trigger: ' + err;
+                                            // disableTrigger(triggerIdentifier, undefined, message);
+                                            // logger.error(method, 'Disabled trigger', triggerIdentifier, 'due to exception:', err);
+                                       
+                                            logger.error(method, 'trigger ', triggerIdentifier, 'could not be started during provider start this time :', err);
+                                            logger.info(method, 'A subsequent provider stop and restart will re-activate the trigger again');
+                                       
                                         });
                                     }
                                 });


### PR DESCRIPTION
Do no more disable triggers in case of Network errors during startup of provider process. 

Also add a  UnhandledRejection listener to ignore unhandled rejections that are exiting processes since nodejs 16 version. 